### PR TITLE
[BUGFIX] Make WelcomeController compatible with SQLite

### DIFF
--- a/lib/welcome_controller_patch.rb
+++ b/lib/welcome_controller_patch.rb
@@ -11,7 +11,10 @@ module WelcomeControllerPatch
   module InstanceMethods
     def index_with_typo3
       @news = News.latest User.current, 2
-      @random_users = User.where("type='User'").limit(10).order("RAND()")
+
+      # use RANDOM() for SQLite, or RAND() for everything else
+      sql_rand_function = ActiveRecord::Base.configurations[Rails.env]['adapter'] == 'sqlite3' ? 'RANDOM()' : 'RAND()'
+      @random_users = User.where("type='User'").limit(10).order(sql_rand_function)
 
       render 'start/index'
     end


### PR DESCRIPTION
The WelcomeControllerPatch uses MySQL 'RAND()' function to get a
random user. This is incompatible with SQLite, which might be
a comfortable alternative during testing.

To allow using SQLite, use 'RANDOM()' instead, if the DB adapter
is 'sqlite3'.