### PR TITLE
[BUGFIX] update feed template to prevent exception during url_for call

### DIFF
--- a/app/views/common/feed.atom.builder
+++ b/app/views/common/feed.atom.builder
@@ -1,8 +1,12 @@
+# frozen_string_literal: true
+
+protocol = Setting.protocol
+host = Setting.host_name
 xml.instruct!
 xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   xml.title   truncate_single_line_raw(@title, 100)
-  xml.link    "rel" => "self", "href" => url_for(params.merge(:only_path => false))
-  xml.link    "rel" => "alternate", "href" => url_for(params.merge(:only_path => false, :format => nil, :key => nil))
+  xml.link    "rel" => "self", "href" => url_for(:params => request.query_parameters, :only_path => false, :format => 'atom', :protocol => protocol, :host => host)
+  xml.link    "rel" => "alternate", "href" => url_for(:params => request.query_parameters.merge(:format => nil, :key => nil), :only_path => false, :protocol => protocol, :host => host)
   xml.id      home_url
   xml.icon    favicon_url
   xml.updated((@items.first ? @items.first.event_datetime : Time.now).xmlschema)
@@ -10,7 +14,7 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
   xml.generator(:uri => Redmine::Info.url) { xml.text! Redmine::Info.app_name; }
   @items.each do |item|
     xml.entry do
-      url = url_for(item.event_url(:only_path => false))
+      url = url_for(item.event_url(:only_path => false, :protocol => protocol, :host => host))
       if @project
         xml.title truncate_single_line_raw(item.event_title, 100)
       else


### PR DESCRIPTION
Adds changes from redmine that fix the parameter handling: https://github.com/redmine/redmine/blob/master/app/views/common/feed.atom.builder